### PR TITLE
フィルタ条件リセット後の再フィルタでの結果表示不正の修正

### DIFF
--- a/js/papamamap.js
+++ b/js/papamamap.js
@@ -150,10 +150,8 @@ Papamamap.prototype.animatedMove = function(lon, lat, isTransform)
  */
 Papamamap.prototype.addNurseryFacilitiesLayer = function(facilitiesData)
 {
-    if(this.map.getLayers().getLength() >= 5) {
-        this.map.removeLayer(this.map.getLayers().item(5));
-        this.map.removeLayer(this.map.getLayers().item(5));
-        this.map.removeLayer(this.map.getLayers().item(5));
+    var layerLength = this.map.getLayers().getLength();
+    for (var i=0; i < layerLength-5; i++) {
         this.map.removeLayer(this.map.getLayers().item(5));
     }
 


### PR DESCRIPTION
フィルタ自体に問題はなかったのですが、リセット時に削除しているレイヤ数が正しくなかった（削除が不足）ので、修正しました。